### PR TITLE
feat: add entity tooltips with CSS hover overlay

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -82,43 +82,20 @@
   list-style-type: lower-roman;
 }
 
-/* Entity tooltip styles */
-.rsw-ce .phrasionary-entity,
-.rsw-ce .dosage-entity {
-  cursor: help;
-  position: relative;
-}
-
-.rsw-ce .phrasionary-entity:hover::after,
-.rsw-ce .dosage-entity:hover::after {
-  content: attr(title);
-  position: absolute;
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #333;
-  color: #fff;
-  padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 12px;
-  white-space: nowrap;
-  z-index: 1000;
-  pointer-events: none;
-  margin-bottom: 4px;
-}
-
 /* Phrasionary link styles */
 .rsw-ce .phrasionary-entity {
   color: #2c5aa0;
   text-decoration: underline;
+  cursor: help;
 }
 
 /* Dosage entity (NGDE) styles - inline badge with emoji icon */
 .rsw-ce .dosage-entity {
-  display: inline-block;
-  font-size: 0.85em;
-  margin: 0 4px;
+  color: #2c5aa0;
+  font-size: 0.8em;
+  text-decoration: underline;
   vertical-align: baseline;
+  cursor: help;
 }
 
 .rsw-html {

--- a/src/styles.css
+++ b/src/styles.css
@@ -82,14 +82,39 @@
   list-style-type: lower-roman;
 }
 
+/* Entity tooltip styles */
+.rsw-ce .phrasionary-entity,
+.rsw-ce .dosage-entity {
+  cursor: help;
+  position: relative;
+}
+
+.rsw-ce .phrasionary-entity:hover::after,
+.rsw-ce .dosage-entity:hover::after {
+  content: attr(title);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  white-space: nowrap;
+  z-index: 1000;
+  pointer-events: none;
+  margin-bottom: 4px;
+}
+
 /* Phrasionary link styles */
-.rsw-ce span[data-content-type='phrasionary'] {
+.rsw-ce .phrasionary-entity {
   color: #2c5aa0;
   text-decoration: underline;
 }
 
 /* Dosage entity (NGDE) styles - inline badge with emoji icon */
-.rsw-ce span.dosage-entity {
+.rsw-ce .dosage-entity {
   display: inline-block;
   font-size: 0.85em;
   margin: 0 4px;

--- a/src/toolbar/buttons.tsx
+++ b/src/toolbar/buttons.tsx
@@ -218,6 +218,8 @@ export const BtnPhrasionary = createButton(
     const span = document.createElement('span');
     span.setAttribute('data-content-type', 'phrasionary');
     span.setAttribute('data-content-id', id);
+    span.setAttribute('class', 'phrasionary-entity');
+    span.setAttribute('title', `Phrasionary: ${id}`);
     span.textContent = text;
 
     range.deleteContents();

--- a/src/utils/contentToHtml.ts
+++ b/src/utils/contentToHtml.ts
@@ -42,7 +42,7 @@ function renderInlineContent(inline: InlineContent): string {
       html += content.value;
     } else if (content.type === 'phrasionary') {
       // Render phrasionary entries as spans
-      html += `<span data-content-type="phrasionary" data-content-id="${content.id}">${content.value}</span>`;
+      html += `<span data-content-type="phrasionary" data-content-id="${content.id}" class="phrasionary-entity" title="Phrasionary: ${content.id}">${content.value}</span>`;
     } else if (content.type === 'ngde') {
       // Render dosage entity as inline badge with emoji icon
       const substanceAttr = content.substanceId


### PR DESCRIPTION
- Add class="phrasionary-entity" and title attribute to phrasionary spans
- Add unified CSS tooltip styles for both phrasionary and dosage entities
- Tooltip appears on hover with question mark cursor
- Uses position: absolute so it overlays without affecting text flow